### PR TITLE
Add light/dark mode with Lucide icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Online Marketing Spezialist
 
 Dies ist eine einfache Landing Page. Oeffnen Sie `index.html` im Browser, um eine Vorschau zu sehen.
+
+Die Seite verfügt nun über einen Schalter für Licht- und Dunkelmodus. Die Symbole werden über die Lucide-Icon-Bibliothek eingebunden.

--- a/index.html
+++ b/index.html
@@ -5,29 +5,60 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Online Marketing Spezialist</title>
     <style>
+        :root {
+            --bg-color: #f5f5f5;
+            --text-color: #000;
+            --header-bg: #333;
+            --header-text: #fff;
+        }
+
         body {
             font-family: Arial, sans-serif;
             margin: 0;
             padding: 0;
             text-align: center;
-            background-color: #f5f5f5;
+            background-color: var(--bg-color);
+            color: var(--text-color);
         }
+
+        body.dark-mode {
+            --bg-color: #121212;
+            --text-color: #f5f5f5;
+            --header-bg: #222;
+            --header-text: #fff;
+        }
+
         header {
-            background-color: #333;
-            color: #fff;
+            background-color: var(--header-bg);
+            color: var(--header-text);
             padding: 2rem 1rem;
+            position: relative;
         }
+
         h1 {
             margin: 0;
             font-size: 2.5rem;
         }
+
+        #theme-toggle {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: inherit;
+        }
+
         main {
             padding: 2rem;
         }
+
         ul {
             list-style: none;
             padding: 0;
         }
+
         li {
             margin: 0.5rem 0;
         }
@@ -36,6 +67,9 @@
 <body>
     <header>
         <h1>Ihr Partner f&uuml;r messbaren Online-Erfolg</h1>
+        <button id="theme-toggle" aria-label="Farbschema wechseln">
+            <i data-lucide="moon"></i>
+        </button>
     </header>
     <main>
         <ul>
@@ -46,5 +80,18 @@
             <li>Datenbasierte Analysen</li>
         </ul>
     </main>
+    <script src="https://cdn.jsdelivr.net/npm/lucide@latest"></script>
+    <script>
+        const toggleBtn = document.getElementById('theme-toggle');
+        const body = document.body;
+
+        toggleBtn.addEventListener('click', () => {
+            const dark = body.classList.toggle('dark-mode');
+            toggleBtn.setAttribute('data-lucide', dark ? 'sun' : 'moon');
+            lucide.createIcons();
+        });
+
+        lucide.createIcons();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement CSS variables for theming
- add button to toggle dark mode
- use Lucide icons for the theme switcher
- document the new feature in README

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest` *(fails: command not found)*